### PR TITLE
코인 + 경험치 추가

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -5975,6 +5975,10 @@ MonoBehaviour:
   uiResult: {fileID: 833415375}
   uiJoy: {fileID: 495292951}
   enemyCleaner: {fileID: 343345482}
+  ItemsRandomSpawnArea: 10
+  coin_spd: 10
+  exp0_spd: 80
+  exp1_spd: 10
 --- !u!4 &283515367
 Transform:
   m_ObjectHideFlags: 0
@@ -10513,6 +10517,8 @@ MonoBehaviour:
   - {fileID: 1453727380183071208, guid: ed1876d06e0f8424e8cefabfca09d430, type: 3}
   - {fileID: 1272332711815712340, guid: 15c34713d43d0a9469e978492fffa98c, type: 3}
   - {fileID: 7831486342206985405, guid: 34b9435f321ba53459bbf0754946eb12, type: 3}
+  - {fileID: 3388508727558375379, guid: 12bf2965133585e43877de5c97560681, type: 3}
+  - {fileID: 7958842504111412297, guid: 74e692234a9feca41b96db56a5895fa8, type: 3}
 --- !u!4 &344728783
 Transform:
   m_ObjectHideFlags: 0
@@ -15915,7 +15921,7 @@ Camera:
   far clip plane: 1000
   field of view: 34
   orthographic: 1
-  orthographic size: 7.9791665
+  orthographic size: 8.37963
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -17544,6 +17550,7 @@ MonoBehaviour:
     health: 15
     speed: 2.4
   levelTime: 0
+  ItemsRandomSpawnArea: 5
 --- !u!1 &882894347
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Undead Survivor/Codes/Enemy.cs
+++ b/Assets/Undead Survivor/Codes/Enemy.cs
@@ -94,11 +94,23 @@ public class Enemy : MonoBehaviour
             anim.SetBool("Dead", true);
             GameManager.Instance.kill++;
             GameManager.Instance.GetExp();
-
+            DropExp();
 
             if (GameManager.Instance.isLive)
                 AudioManager.Instance.PlaySfx(AudioManager.Sfx.Dead);
         }
+    }
+
+    void DropExp()
+    {
+        int tmp = Random.RandomRange(0, 100);
+        if (tmp > 20) // 확률적으로 Exp 드롭
+        {
+            return;
+        }
+        GameObject Exp = GameManager.Instance.pool.Get(4);
+        Exp.transform.position = new Vector2(transform.position.x, transform.position.y);
+
     }
 
     //코루틴 - 비동기

--- a/Assets/Undead Survivor/Codes/GameManager.cs
+++ b/Assets/Undead Survivor/Codes/GameManager.cs
@@ -31,6 +31,13 @@ public class GameManager : MonoBehaviour
     public Result uiResult;
     public Transform uiJoy;
     public GameObject enemyCleaner;
+
+    [Header("# Item Spawn")]
+    public float ItemsRandomSpawnArea = 10;
+    public float coin_spd = 10;
+    public float exp0_spd = 80;
+    public float exp1_spd = 10;
+
     private void Awake()
     {
         Instance = this;
@@ -111,16 +118,28 @@ public class GameManager : MonoBehaviour
         }
 
     }
-    public void GetExp()
+    public void GetExp() //.. 1만큼 증가하는 경험치 획득 함수
     {
         if (!isLive)
             return;
         exp++;
-
-        if(exp == nextExp[Mathf.Min(level, nextExp.Length-1)])//index bound error 안 나오도록
+        if (exp >= nextExp[Mathf.Min(level, nextExp.Length - 1)]) //index bound error 안 나오도록
         {
             level++;
             exp = 0;
+            uiLevelUp.Show();
+        }
+    }
+    public void GetExp(int e) //... e만큼 증가하는 경험치 획득 함수
+    {
+        if (!isLive)
+            return;
+        exp += e;
+        int nextexp = nextExp[Mathf.Min(level, nextExp.Length - 1)]; //index bound error 안 나오도록
+        if (exp >= nextexp)
+        {
+            level++;
+            exp = exp - nextexp;
             uiLevelUp.Show();
         }
     }

--- a/Assets/Undead Survivor/Codes/Magnet.cs
+++ b/Assets/Undead Survivor/Codes/Magnet.cs
@@ -13,14 +13,29 @@ public class Magnet : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (!collision.CompareTag("Coin"))
-            return;
+        if (collision.CompareTag("Coin"))
+        {
+            GameManager.Instance.money++;
 
-        GameManager.Instance.money++;
+            Debug.Log("코인과 충돌 발생");
 
-        Debug.Log("코인과 충돌 발생");
+            collision.gameObject.SetActive(false);
+        }
+        else if (collision.CompareTag("Exp 0")) {
+            GameManager.Instance.GetExp();
 
-        collision.gameObject.SetActive(false);
+            Debug.Log("경험치와 충돌 발생");
+
+            collision.gameObject.SetActive(false);
+        }
+        else if (collision.CompareTag("Exp 1"))
+        {
+            GameManager.Instance.GetExp(10);
+
+            Debug.Log("메가경험치 충동");
+
+            collision.gameObject.SetActive(false);
+        }
     }
 
     private void LevelUpColliderRadius()

--- a/Assets/Undead Survivor/Codes/Spawner.cs
+++ b/Assets/Undead Survivor/Codes/Spawner.cs
@@ -7,6 +7,7 @@ public class Spawner : MonoBehaviour
     public Transform[] spawnPoint;
     public SpawnData[] spawnData;
     public float levelTime;
+    public float ItemsRandomSpawnArea; //.. 플레이어 주위로 아이템 스폰되는 써클의 반지름
 
     int level;
     float timer;
@@ -17,6 +18,8 @@ public class Spawner : MonoBehaviour
         //자기 자신을 포함한 자식들 component 싹다 갖고옴
 
         levelTime = GameManager.Instance.maxGameTime / spawnData.Length;
+
+        ItemsRandomSpawnArea = GameManager.Instance.ItemsRandomSpawnArea;
 
         StartCoroutine(CreateCoinRoutine());
     }
@@ -32,7 +35,7 @@ public class Spawner : MonoBehaviour
         if (timer > spawnData[level].spawnTime)
         {
             timer = 0f;
-            Spwan();
+            SpwanEnemy();
         }
  
     }
@@ -42,10 +45,11 @@ public class Spawner : MonoBehaviour
         while (true)
         {
             yield return new WaitForSeconds(1);
-            SpawnCoin();
+            int randomItemNum = SelectRandomItem();
+            SpawnItem(randomItemNum);
         }
     }
-    void Spwan()
+    void SpwanEnemy()
     {
         GameObject enemy = GameManager.Instance.pool.Get(0);
         enemy.transform.position = spawnPoint[Random.Range(1, spawnPoint.Length)].position;
@@ -53,11 +57,30 @@ public class Spawner : MonoBehaviour
         enemy.GetComponent<Enemy>().Init(spawnData[level]);
     }
 
-    void SpawnCoin()
+    int SelectRandomItem() //.. 게임매니저의 아이템 별 degree수치에 따라 확률적으로 아이템 번호를 선택하는 함수
     {
-        GameObject coin = GameManager.Instance.pool.Get(3);
-        coin.transform.position = new Vector2(transform.position.x, transform.position.y) + Random.insideUnitCircle * 5;
+        int resultItem;
+        float coin_spd = GameManager.Instance.coin_spd;
+        float exp0_spd = GameManager.Instance.exp0_spd;
+        float exp1_spd = GameManager.Instance.exp1_spd;
 
+        float total_spd = coin_spd + exp0_spd + exp1_spd;
+        float select_spd = Random.Range(0f, total_spd);
+
+        if (select_spd < coin_spd)
+            resultItem = 3;
+        else if (select_spd < coin_spd + exp0_spd)
+            resultItem = 4;
+        else
+            resultItem = 5;
+        return resultItem;
+    }
+
+    void SpawnItem(int itemNum) // 3 : 코인, 4 : Exp 0, 5 : Exp 1
+    {
+        GameObject item = GameManager.Instance.pool.Get(itemNum);
+        item.transform.position = new Vector2(transform.position.x, transform.position.y) + Random.insideUnitCircle * ItemsRandomSpawnArea;
+        
     }
 }
 

--- a/Assets/Undead Survivor/Prefabs/Exp 0.prefab
+++ b/Assets/Undead Survivor/Prefabs/Exp 0.prefab
@@ -1,0 +1,122 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3388508727558375379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7412323128183018612}
+  - component: {fileID: 8893903059885899287}
+  - component: {fileID: -4293599316323199061}
+  m_Layer: 0
+  m_Name: Exp 0
+  m_TagString: Exp 0
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7412323128183018612
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3388508727558375379}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8893903059885899287
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3388508727558375379}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 362616440, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.5555556, y: 0.6111111}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &-4293599316323199061
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3388508727558375379}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.30555555

--- a/Assets/Undead Survivor/Prefabs/Exp 0.prefab.meta
+++ b/Assets/Undead Survivor/Prefabs/Exp 0.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12bf2965133585e43877de5c97560681
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Prefabs/Exp 1.prefab
+++ b/Assets/Undead Survivor/Prefabs/Exp 1.prefab
@@ -1,0 +1,122 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7958842504111412297
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7991674714018878724}
+  - component: {fileID: 8970980163798443063}
+  - component: {fileID: 1038656944043852304}
+  m_Layer: 0
+  m_Name: Exp 1
+  m_TagString: Exp 1
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7991674714018878724
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7958842504111412297}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8970980163798443063
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7958842504111412297}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 1807624531, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.5555556, y: 0.6111111}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &1038656944043852304
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7958842504111412297}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.30555555

--- a/Assets/Undead Survivor/Prefabs/Exp 1.prefab.meta
+++ b/Assets/Undead Survivor/Prefabs/Exp 1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74e692234a9feca41b96db56a5895fa8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -9,6 +9,8 @@ TagManager:
   - Enemy
   - Bullet
   - Coin
+  - Exp 0
+  - Exp 1
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
경험치 소짜, 대짜 추가
태그 추가함
대짜먹으면 경험치 10 증가
소짜는 1증가
몬스터 죽일 시, 확률적으로 경험치 드롭
코인과 경험치0, 겸험치1은 각각 10, 80, 10의 비율로 스폰됨. 이는 게임매니저에서 변경가능 위 3가지 아이템 드롭하는 반경은 (원의 반지름) ItemsRandomSpawnArea