### PR TITLE
윤재영

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -10519,10 +10519,6 @@ MonoBehaviour:
   - {fileID: 1453727380183071208, guid: ed1876d06e0f8424e8cefabfca09d430, type: 3}
   - {fileID: 1272332711815712340, guid: 15c34713d43d0a9469e978492fffa98c, type: 3}
   - {fileID: 7831486342206985405, guid: 34b9435f321ba53459bbf0754946eb12, type: 3}
-  - {fileID: 3388508727558375379, guid: 12bf2965133585e43877de5c97560681, type: 3}
-  - {fileID: 7958842504111412297, guid: 74e692234a9feca41b96db56a5895fa8, type: 3}
-  - {fileID: 6652516139621229888, guid: 49878a9c90fba024aaf690bfe067d688, type: 3}
-  - {fileID: 5544009488469751532, guid: b7ff89ced615a844cb6328d76640fa11, type: 3}
 --- !u!4 &344728783
 Transform:
   m_ObjectHideFlags: 0
@@ -15925,7 +15921,7 @@ Camera:
   far clip plane: 1000
   field of view: 34
   orthographic: 1
-  orthographic size: 8.37963
+  orthographic size: 8.180555
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -16780,6 +16776,7 @@ Transform:
   - {fileID: 877631950}
   - {fileID: 1231472776}
   - {fileID: 1991764579}
+  - {fileID: 1268665928}
   - {fileID: 1506284887}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -17555,6 +17552,12 @@ MonoBehaviour:
     speed: 2.4
   levelTime: 0
   ItemsRandomSpawnArea: 5
+  itemDatas:
+  - {fileID: 11400000, guid: 8a0acfa879051b64192d3ffee5df878e, type: 2}
+  - {fileID: 11400000, guid: 5e0ad0c8ad5af724c92c1c15bfd46b38, type: 2}
+  - {fileID: 11400000, guid: 327c1116655536747baeb63805b1456f, type: 2}
+  - {fileID: 11400000, guid: a400248412fa5804ab1e40275ae572b4, type: 2}
+  - {fileID: 11400000, guid: a92ae6acbc93d1440b97d076b72490e8, type: 2}
 --- !u!1 &882894347
 GameObject:
   m_ObjectHideFlags: 0
@@ -18789,6 +18792,86 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isLeft: 1
   spriteRenderer: {fileID: 1231472777}
+--- !u!1 &1268665927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1268665928}
+  - component: {fileID: 1268665930}
+  - component: {fileID: 1268665929}
+  m_Layer: 0
+  m_Name: Collector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1268665928
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1268665927}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 731594820}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1268665929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1268665927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d05704865bd00f8428c2ee85c8b6bce8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!58 &1268665930
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1268665927}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.25
 --- !u!1 &1286317716
 GameObject:
   m_ObjectHideFlags: 0
@@ -19677,7 +19760,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 1
 --- !u!114 &1506284889
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -19690,6 +19773,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1a225d7f30940848a9893b4e20636cd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  radius: 1
 --- !u!1 &1550353509
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Undead Survivor/Codes/Collector.cs
+++ b/Assets/Undead Survivor/Codes/Collector.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Collector : MonoBehaviour
+{
+    //아이템 습득을 담당
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (!collision.CompareTag("Item"))
+            return;
+
+        SpawnItemData data = collision.GetComponent<SpawnItem>().data;//충돌한 아이템의 데이터를 받아온다.
+
+        //아이템의 itemType에 따라 분류하고, 해당하는 효과를 발휘한다.(value만큼 증가한다.)
+        switch (data.itemType)
+        {
+            case SpawnItemData.ItemType.Coin:
+                Debug.Log(string.Format("코인 {0}만큼 먹음", data.value));
+                GameManager.Instance.money += data.value;
+                break;
+            case SpawnItemData.ItemType.EXP:
+                Debug.Log(string.Format("경험치 {0}만큼 먹음", data.value));
+                GameManager.Instance.GetExp(data.value);
+                break;
+            case SpawnItemData.ItemType.Buff:
+                //GameManager.Instance.money += data.value;
+                Debug.Log("버프 아이템 먹음");
+                break;
+            case SpawnItemData.ItemType.Heal:
+                Debug.Log("힐 아이템 먹음");
+                //GameManager.Instance.money += data.value;
+                break;
+        }
+
+        collision.gameObject.SetActive(false);//이후 아이템을 없앤다.
+    }
+}

--- a/Assets/Undead Survivor/Codes/Collector.cs.meta
+++ b/Assets/Undead Survivor/Codes/Collector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d05704865bd00f8428c2ee85c8b6bce8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Codes/Enemy.cs
+++ b/Assets/Undead Survivor/Codes/Enemy.cs
@@ -94,13 +94,14 @@ public class Enemy : MonoBehaviour
             anim.SetBool("Dead", true);
             GameManager.Instance.kill++;
             GameManager.Instance.GetExp();
-            DropExp();
+            //DropExp();
 
             if (GameManager.Instance.isLive)
                 AudioManager.Instance.PlaySfx(AudioManager.Sfx.Dead);
         }
     }
 
+    /*
     void DropExp()
     {
         int tmp = Random.RandomRange(0, 100);
@@ -108,10 +109,11 @@ public class Enemy : MonoBehaviour
         {
             return;
         }
-        GameObject Exp = GameManager.Instance.pool.Get(4);
+        GameObject Exp = GameManager.Instance.pool.Get(3);
+        Exp.GetComponent<SpawnItem>().Init(Spawner.itemDatas[2]);
         Exp.transform.position = new Vector2(transform.position.x, transform.position.y);
 
-    }
+    }*/
 
     //코루틴 - 비동기
     IEnumerator KnockBack()

--- a/Assets/Undead Survivor/Codes/Magnet.cs
+++ b/Assets/Undead Survivor/Codes/Magnet.cs
@@ -4,54 +4,33 @@ using UnityEngine;
 
 public class Magnet : MonoBehaviour
 {
-    CircleCollider2D coll;
+    [SerializeField]
+    private float radius; //아직은 사용되지 않음
+
+    CircleCollider2D coll; // 자력 범위를 설정할 Collider
 
     private void Awake()
     {
         coll = GetComponent<CircleCollider2D>();
+        radius = coll.radius;
     }
+
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.CompareTag("Coin"))
+        if (!collision.CompareTag("Item"))//Item만을 끌어당긴다.
+            return;
+
+
+        MagnetableItem magnet;//현재 충돌한 아이템의 스크립트를 불러와
+        if (!collision.TryGetComponent<MagnetableItem>(out magnet))
         {
-            GameManager.Instance.money++;
-
-            Debug.Log("코인과 충돌 발생");
-
-            collision.gameObject.SetActive(false);
+            Debug.LogWarning("TryGetComponent문 실패했을 경우 실행됨");
+            return;
         }
-        else if (collision.CompareTag("Exp 0")) {
-            GameManager.Instance.GetExp();
-
-            Debug.Log("경험치와 충돌 발생");
-
-            collision.gameObject.SetActive(false);
-        }
-        else if (collision.CompareTag("Exp 1"))
-        {
-            GameManager.Instance.GetExp(10);
-
-            Debug.Log("메가경험치 충동");
-
-            collision.gameObject.SetActive(false);
-        }
-        else if (collision.CompareTag("Health"))
-        {
-            GameManager.Instance.GetHealth(10); // 10만큼 체력 회복
-
-            Debug.Log("체력 충동");
-
-            collision.gameObject.SetActive(false);
-        }
-        else if (collision.CompareTag("Mag")) // 일단은 영구 증가?
-        {
-
-            StartCoroutine(CreateMagRoutine());
+            magnet.ActiveMagnet(coll.radius);//자석을 활성화 한다.
 
 
-            collision.gameObject.SetActive(false);
-        }
 
     }
 

--- a/Assets/Undead Survivor/Codes/MagnetableItem.cs
+++ b/Assets/Undead Survivor/Codes/MagnetableItem.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+
+public class MagnetableItem : MonoBehaviour
+{
+    Rigidbody2D rb;//물체의 속도를 0으로 할 때 사용.
+
+    Transform target;//플레이어의 위치 및, Magnet의 반경에 들어왔는지 확인함
+    float MagneticConst;//자력 상수
+    
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        target = null;
+    }
+    
+    //아이템을 먹어 비활성화 될 때, 타겟을 없앤다
+    private void OnDisable()
+    {
+        target = null;
+    }
+
+    private void FixedUpdate()
+    {
+        if (target == null)//타겟이 없는 경우 - 자력 범위에 들어오지 않은 경우.
+            return;
+
+        Vector2 directionVect = target.position - transform.position; // 코인 -> 플레이어 벡터 구하기
+        float distance = directionVect.magnitude; //거리 구하기
+        Vector2 MagneticForce = directionVect.normalized * MagneticConst / distance; // 자기력 구하기
+        if (MagneticForce.magnitude < 0.5f) //자기력이 너무 작다면(= 속도가 너무 느리다면) 일정 수준(0.5)으로 보정
+            MagneticForce = MagneticForce.normalized * 0.5f;
+        transform.Translate(MagneticForce * Time.fixedDeltaTime); //코인의 좌표를 벡터 * 프레임 만큼 이동시키기
+        rb.velocity = Vector2.zero; // 속도의 영향을 받지않도록 속도를 제거
+    }
+
+    //Player 자식 오브젝트인 Magnet의 Collider에 코인, 경험치 등의 자력의 영향을 받는 아이템이 들어올 경우 이 함수가 호출되어 target과 자력이 활성화되고
+    //이후 Player쪽으로 움직이다가 Player의 자식 오브젝트인 Collector의 Collider에서 물건을 습득하도록 처리.
+    public void ActiveMagnet(float radius)
+    {
+        target = GameManager.Instance.player.transform;
+        this.MagneticConst = radius * 2f;
+    }
+}

--- a/Assets/Undead Survivor/Codes/MagnetableItem.cs.meta
+++ b/Assets/Undead Survivor/Codes/MagnetableItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f97b9907e559944687e3f9e98ce5ed9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Codes/Player.cs
+++ b/Assets/Undead Survivor/Codes/Player.cs
@@ -74,6 +74,7 @@ public class Player : MonoBehaviour
             GameManager.Instance.GameOver();
         }
     }
+   
 }
 
 

--- a/Assets/Undead Survivor/Codes/PoolManager.cs
+++ b/Assets/Undead Survivor/Codes/PoolManager.cs
@@ -10,6 +10,8 @@ public class PoolManager : MonoBehaviour
 
     // .. 풀 담당 리스트들
     List<GameObject>[] pools;
+    
+    //현재 0-적, 1-삽, 2-총, 3-아이템 으로 설정되어있음.
 
     private void Awake()
     {

--- a/Assets/Undead Survivor/Codes/SpawnItem.cs
+++ b/Assets/Undead Survivor/Codes/SpawnItem.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//맵에 스폰되는 아이템 prefab에 들어가는 스크립트
+//prefab은 Coin 하나만을 사용했음
+public class SpawnItem : MonoBehaviour
+{
+    public SpawnItemData data;
+    SpriteRenderer spriteRenderer; //이미지 변경을 위한 SpriteRenderer
+    private void Awake()
+    {
+        spriteRenderer = GetComponent<SpriteRenderer>();
+    }
+    //Spawner에서 아이템을 스폰할 때, Init함수를 호출함.
+    public void Init(SpawnItemData data)
+    {
+        this.data = data;//Spawner에 있는 itemDatas 배열에 있는 데이터(Inspector상에서 보면 아이템의 Scriptable Object 데이터가 들어가있음) 배열에서 데이터를 받아와 설정
+        spriteRenderer.sprite = data.image;//아이템에 맞게 이미지 변경
+        GetComponent<MagnetableItem>().enabled = data.magnetable;//자석의 영향을 받지않는 버프 아이템들은
+        //자석같은 움직임을 담당하는 MagnetableItem 스크립트를 비활성화 시켜 움직이지 않도록 함.
+    }
+    private void OnDisable()
+    {
+        GetComponent<MagnetableItem>().enabled = false;
+    }
+}

--- a/Assets/Undead Survivor/Codes/SpawnItem.cs.meta
+++ b/Assets/Undead Survivor/Codes/SpawnItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3863777eb4f810345a05df85d80331d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Codes/SpawnItemData.cs
+++ b/Assets/Undead Survivor/Codes/SpawnItemData.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+//맵에 스폰되는 아이템을 ScriptableObject로 만들어, Spawner의 itemDatas 배열에 할당함.
+//여기에 드롭율 추가 고려
+
+//해당 ScriptableObject로 생성된 데이터는 Data/SpawnItemData에 있음.
+
+
+[CreateAssetMenu(fileName = "Item", menuName = "Scriptable Object/SpawnItemData")]
+public class SpawnItemData : ScriptableObject
+{
+    public enum ItemType{ Coin, EXP, Buff, Heal } //아이템 종류 구분
+    public enum BuffEffect { Power, Speed, Defense, Magnetic, Invincible, None } // 버프 아이템 효과 구분
+
+    [Header("# Main Info")]
+    public ItemType itemType; // 아이템 종류
+    public int itemId; // 아이템 Id - 없어도 될 것 같긴한데 혹시 몰라서 넣어둠
+    public Sprite image; // 이미지-맵에 표시될 이미지
+    public bool magnetable; //자력 영향 여부
+
+    [Header("# value")]
+    public int value; //값 (코인양, 경험치량, 힐양, 버프 수치 등등)
+
+    [Header("# Buff Item Info")]
+    public BuffEffect buffType;//버프효과 설정
+    public float duration;//버프 지속시간 설정
+
+    [Header("# Prefab(GameObject)")]
+    public GameObject prefab;//프리팹 - Coin으로 동일함
+    //Coin 내부에는 자석효과를 위한 Rigidbody2D와 Magnetable(자석 움직임 구현) 스크립트, 자석효과와 아이템 습득을 구현하는 CircleCollider2D가 있으며.
+    //Tag는 Item으로 설정되어있다.
+
+
+    
+
+}

--- a/Assets/Undead Survivor/Codes/SpawnItemData.cs.meta
+++ b/Assets/Undead Survivor/Codes/SpawnItemData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f46866a660e2d344cb6fc5c1a3951234
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Codes/Spawner.cs
+++ b/Assets/Undead Survivor/Codes/Spawner.cs
@@ -12,6 +12,10 @@ public class Spawner : MonoBehaviour
     int level;
     float timer;
 
+    public SpawnItemData[] itemDatas;
+    //public int[] drop_rates; // 나중에 아이템에 드롭율을 넣게 된다면 설정.
+    //private int total_drop_rate;
+
     private void Awake()
     {
         spawnPoint = GetComponentsInChildren<Transform>();
@@ -20,6 +24,8 @@ public class Spawner : MonoBehaviour
         levelTime = GameManager.Instance.maxGameTime / spawnData.Length;
 
         ItemsRandomSpawnArea = GameManager.Instance.ItemsRandomSpawnArea;
+
+        //drop_rates = new int[items.Length];
 
         StartCoroutine(CreateCoinRoutine());
     }
@@ -69,6 +75,7 @@ public class Spawner : MonoBehaviour
         float total_spd = coin_spd + exp0_spd + exp1_spd + health_spd + mag_spd;
         float select_spd = Random.Range(0f, total_spd);
 
+        /* //이전 코드
         if (select_spd < coin_spd)
             resultItem = 3;
         else if (select_spd < coin_spd + exp0_spd)
@@ -79,12 +86,28 @@ public class Spawner : MonoBehaviour
             resultItem = 6;
         else
             resultItem = 7;
+        return resultItem;*/
+
+
+        //resultItem을 itemDatas배열의 인덱스로 사용.
+        if (select_spd < coin_spd)
+            resultItem = 0;
+        else if (select_spd < coin_spd + exp0_spd)
+            resultItem = 1;
+        else if (select_spd < coin_spd + exp0_spd + exp1_spd)
+            resultItem = 2;
+        else if (select_spd < coin_spd + exp0_spd + exp1_spd + health_spd)
+            resultItem = 3;
+        else
+            resultItem = 4;
         return resultItem;
+
     }
 
     void SpawnItem(int itemNum) // 3 : 코인, 4 : Exp 0, 5 : Exp 1
     {
-        GameObject item = GameManager.Instance.pool.Get(itemNum);
+        GameObject item = GameManager.Instance.pool.Get(3);
+        item.GetComponent<SpawnItem>().Init(itemDatas[itemNum]);
         item.transform.position = new Vector2(transform.position.x, transform.position.y) + Random.insideUnitCircle * ItemsRandomSpawnArea;
         
     }

--- a/Assets/Undead Survivor/Complete Pack.unitypackage.meta
+++ b/Assets/Undead Survivor/Complete Pack.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e951369ddfea26544b3e421fb529cf30
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Data/SpawnItemData.meta
+++ b/Assets/Undead Survivor/Data/SpawnItemData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0648fe38525fcbd44a1d53e92336d2c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Data/SpawnItemData/Coin.asset
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Coin.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f46866a660e2d344cb6fc5c1a3951234, type: 3}
+  m_Name: Coin
+  m_EditorClassIdentifier: 
+  itemType: 0
+  itemId: 0
+  image: {fileID: -1997803578, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  magnetable: 1
+  value: 1
+  buffType: 5
+  duration: 0
+  prefab: {fileID: 7831486342206985405, guid: 34b9435f321ba53459bbf0754946eb12, type: 3}

--- a/Assets/Undead Survivor/Data/SpawnItemData/Coin.asset.meta
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Coin.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a0acfa879051b64192d3ffee5df878e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Data/SpawnItemData/Exp 0.asset
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Exp 0.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f46866a660e2d344cb6fc5c1a3951234, type: 3}
+  m_Name: Exp 0
+  m_EditorClassIdentifier: 
+  itemType: 1
+  itemId: 1
+  image: {fileID: 362616440, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  magnetable: 1
+  value: 5
+  buffType: 5
+  duration: 0
+  prefab: {fileID: 7831486342206985405, guid: 34b9435f321ba53459bbf0754946eb12, type: 3}

--- a/Assets/Undead Survivor/Data/SpawnItemData/Exp 0.asset.meta
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Exp 0.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e0ad0c8ad5af724c92c1c15bfd46b38
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Data/SpawnItemData/Exp 1.asset
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Exp 1.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f46866a660e2d344cb6fc5c1a3951234, type: 3}
+  m_Name: Exp 1
+  m_EditorClassIdentifier: 
+  itemType: 1
+  itemId: 2
+  image: {fileID: 1807624531, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  magnetable: 1
+  value: 10
+  buffType: 5
+  duration: 0
+  prefab: {fileID: 7831486342206985405, guid: 34b9435f321ba53459bbf0754946eb12, type: 3}

--- a/Assets/Undead Survivor/Data/SpawnItemData/Exp 1.asset.meta
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Exp 1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 327c1116655536747baeb63805b1456f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Data/SpawnItemData/Health.asset
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Health.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f46866a660e2d344cb6fc5c1a3951234, type: 3}
+  m_Name: Health
+  m_EditorClassIdentifier: 
+  itemType: 3
+  itemId: 3
+  image: {fileID: 934571490, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  magnetable: 0
+  value: 5
+  buffType: 5
+  duration: 0
+  prefab: {fileID: 7831486342206985405, guid: 34b9435f321ba53459bbf0754946eb12, type: 3}

--- a/Assets/Undead Survivor/Data/SpawnItemData/Health.asset.meta
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Health.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a400248412fa5804ab1e40275ae572b4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Data/SpawnItemData/Mag.asset
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Mag.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f46866a660e2d344cb6fc5c1a3951234, type: 3}
+  m_Name: Mag
+  m_EditorClassIdentifier: 
+  itemType: 2
+  itemId: 4
+  image: {fileID: 1997828774, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  magnetable: 0
+  value: 1
+  buffType: 3
+  duration: 10
+  prefab: {fileID: 7831486342206985405, guid: 34b9435f321ba53459bbf0754946eb12, type: 3}

--- a/Assets/Undead Survivor/Data/SpawnItemData/Mag.asset.meta
+++ b/Assets/Undead Survivor/Data/SpawnItemData/Mag.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a92ae6acbc93d1440b97d076b72490e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Undead Survivor/Prefabs/Coin.prefab
+++ b/Assets/Undead Survivor/Prefabs/Coin.prefab
@@ -11,10 +11,12 @@ GameObject:
   - component: {fileID: 920465040198925059}
   - component: {fileID: 5852948188818577464}
   - component: {fileID: -876539815106086653}
-  - component: {fileID: 667120017096919980}
+  - component: {fileID: 1136301348640667503}
+  - component: {fileID: 3146841347537112585}
+  - component: {fileID: 3197956333030521073}
   m_Layer: 0
   m_Name: Coin
-  m_TagString: Coin
+  m_TagString: Item
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -121,7 +123,19 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 0.30555555
---- !u!50 &667120017096919980
+--- !u!114 &1136301348640667503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7831486342206985405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f97b9907e559944687e3f9e98ce5ed9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!50 &3146841347537112585
 Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 0
@@ -147,4 +161,16 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
+--- !u!114 &3197956333030521073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7831486342206985405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3863777eb4f810345a05df85d80331d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Undead Survivor/Prefabs/Exp 0.prefab
+++ b/Assets/Undead Survivor/Prefabs/Exp 0.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: -4293599316323199061}
   m_Layer: 0
   m_Name: Exp 0
-  m_TagString: Exp 0
+  m_TagString: Magnetable
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Undead Survivor/Prefabs/Exp 1.prefab
+++ b/Assets/Undead Survivor/Prefabs/Exp 1.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 1038656944043852304}
   m_Layer: 0
   m_Name: Exp 1
-  m_TagString: Exp 1
+  m_TagString: Magnetable
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,11 +8,12 @@ TagManager:
   - Area
   - Enemy
   - Bullet
-  - Coin
   - Exp 0
   - Exp 1
   - Health
   - Mag
+  - Magnetable
+  - Item
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
**자석 효과 구현 및 아이템 태그, 데이터 양식 통일**

1.Scriptable Object를 이용한 아이템 스폰 데이터 구현 - prefab을 Coin 하나만 사용하고 이미지와 값만을 변경하여 다른 아이템으로 인식하도록 구현함.

2.Poolmanager.cs 수정 - 아이템이 모두 동일하게 4번 인덱스의 풀을 사용하도록 수정
3.Spawner.cs에 1의 아이템 데이터를 넣도록 itemDatas 배열을 추가하고 해당 배열에서 확률에 따라 아이템이 스폰 되도록 수정.
4.코인 prefab의 태그를 item으로 수정하고 자석효과가 태그가 item이며 Scriptable Object Data에서 Magnetable 속성이 true인 아이템에게만 적용되도록 함.
5.물건 습득용 Player의 자식 오브젝트인 Collecter를 생성하고 Collecter.cs의 OnTrigger에서 처리하도록 함.

6.현재 PoolManager가 수정되어 Enemy에 있던 DropExp함수에서 BoundOfArray 에러가 발생했음. 이 부분은 현재 주석처리 했으며, 나중에 Spawner의 함수를 새로 만들어 현재 적이 죽은 위치를 전달하여 생성하는 식으로 구현할지, 아니면 그냥 데이터를 받아와서 Enemy에서 생성할지에 대해 고민중.