### PR TITLE
마프, Iot, BasedSkill 문제 해결

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -12571,7 +12571,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d7c1becfe27c0d4ca0f2aa43bc81958, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  lifeTime: 0
   damage: 10000000
+  speed: 0
+  count: 0
+  attackCoolTime: 0
+  scaleFactor: 0
+  flightTime: 0
+  rotateSpeed: 0
+  playerTransform: {fileID: 0}
+  boltSpeed: 0
   per: -1
 --- !u!61 &343345484
 BoxCollider2D:
@@ -23328,20 +23337,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SkillSelectRates:
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
   - 1
   - 1
   - 1

--- a/Assets/Undead Survivor/Codes/Bullet.cs
+++ b/Assets/Undead Survivor/Codes/Bullet.cs
@@ -2,9 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Bullet : MonoBehaviour
+public class Bullet : BulletBase
 {
-    public float damage;
+    public float boltSpeed;
     public int per;
 
     Rigidbody2D rigid;
@@ -16,13 +16,12 @@ public class Bullet : MonoBehaviour
 
     public void Init(float damage, int per, Vector3 dir)
     {
-        this.damage = damage;
+        putDamage(damage);
         this.per = per;
-        GetComponentInParent<A_Skill_Data>().damage = damage; // 외부에서 참조하기 쉽게 따로 데미지 표시
 
         if (per >= 0)
         {
-            rigid.velocity = dir * 15f;
+            rigid.velocity = dir * boltSpeed;
         }
     }
 

--- a/Assets/Undead Survivor/Codes/Skills/BasedSkill.cs
+++ b/Assets/Undead Survivor/Codes/Skills/BasedSkill.cs
@@ -15,6 +15,7 @@ public class BasedSkill : MonoBehaviour
     public SkillData skillData;
 
     Player player;
+    Transform playerTransform;
     float timer;
     bool isAI;
     private void Awake()
@@ -45,8 +46,8 @@ public class BasedSkill : MonoBehaviour
 
         coolTime = skillData.cooltimes[level];
 
-        player.BroadcastMessage("ApplyGear", SendMessageOptions.DontRequireReceiver);
-        player.BroadcastMessage("ApplyCooldown", SendMessageOptions.DontRequireReceiver);
+        playerTransform.BroadcastMessage("ApplyGear", SendMessageOptions.DontRequireReceiver);
+        playerTransform.BroadcastMessage("ApplyCooldown", SendMessageOptions.DontRequireReceiver);
     }
     public void Init(bool isAI, SkillData skillData)
     {
@@ -56,11 +57,13 @@ public class BasedSkill : MonoBehaviour
         name = "SKILL " + skillData.skillName; // 오브젝트 name을 설정하는거임
         if (isAI)
         {
-            transform.parent = GameManager.Instance.ai_Player.transform;
+            playerTransform = GameManager.Instance.ai_Player.transform;
+            transform.parent = playerTransform;
         }
         else
         {
-            transform.parent = player.transform;
+            playerTransform = GameManager.Instance.player.transform;
+            transform.parent = playerTransform;
         }
         transform.localPosition = Vector3.zero;
         coolTime = skillData.cooltimes[0];
@@ -93,13 +96,13 @@ public class BasedSkill : MonoBehaviour
 
         //나중에 추가된 무기에도 버프가 적용되도록
         //이 함수를 갖고있는 애들 다 실행해라 방송
-        player.BroadcastMessage("ApplyGear", SendMessageOptions.DontRequireReceiver);
-        player.BroadcastMessage("ApplyCooldown", SendMessageOptions.DontRequireReceiver);
+        playerTransform.BroadcastMessage("ApplyGear", SendMessageOptions.DontRequireReceiver);
+        playerTransform.BroadcastMessage("ApplyCooldown", SendMessageOptions.DontRequireReceiver);
     }
 
     void Fire()
     {
-        if (!player.scanner.nearestTarget)
+        if (!playerTransform.GetComponent<Scanner>().nearestTarget)
             return;
         GameObject bullet = GameManager.Instance.pool.Get(prefabId);
         bullet.GetComponent<BulletBase>().Init(isAI, skillData, level); // 새로 호출되거나 레벨업 시에만 유의미함

--- a/Assets/Undead Survivor/Codes/Skills/Bullet_Microprocessor.cs
+++ b/Assets/Undead Survivor/Codes/Skills/Bullet_Microprocessor.cs
@@ -2,13 +2,12 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Bullet_Microprocessor : MonoBehaviour
+public class Bullet_Microprocessor : BulletBase
 {
     Transform lineTracer;
     Transform lineTracerCollider;
     
     Vector3[] positions;
-    public float speed = 3f;
     WaitForFixedUpdate wait = new WaitForFixedUpdate();
     private void Awake()
     {
@@ -25,15 +24,16 @@ public class Bullet_Microprocessor : MonoBehaviour
         positions[5] = new Vector3(0, -1, 0) * 2;
     }
 
-    
-
-    private void OnEnable()
+    public override void Init(bool isAI, SkillData skillData, int level)
     {
-        transform.parent = GameManager.Instance.player.transform;
-        transform.position = GameManager.Instance.player.transform.position;
+        base.Init(isAI, skillData, level);
+
+        transform.parent = playerTransform;
+        transform.localPosition = Vector3.zero;
         lineTracer.rotation = Quaternion.Euler(0, 0, 180f);
         StartCoroutine(LineTracerRoutine(() => { gameObject.SetActive(false); }));
     }
+
     IEnumerator LineTracerRoutine(System.Action done)
     {
         for(int i = 1; i < positions.Length; i++)

--- a/Assets/Undead Survivor/Complete Pack.unitypackage.meta
+++ b/Assets/Undead Survivor/Complete Pack.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: e951369ddfea26544b3e421fb529cf30
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Undead Survivor/Data/Skill/Skill 9.asset
+++ b/Assets/Undead Survivor/Data/Skill/Skill 9.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   skillIcon: {fileID: -155058199, guid: d71a3dc7aa20fad4f9a99fc76a9254ba, type: 3}
   bulletPrefab: {fileID: 5665052994215594943, guid: f72040c2bc43fa244954dcd643287080, type: 3}
   pool_index: 0
+  getype: 0
   cooltimes:
   - 7
   - 5
@@ -34,8 +35,8 @@ MonoBehaviour:
   - 6
   - 10
   speeds:
-  - 1
-  - 2
+  - 3
+  - 3
   - 3
   counts:
   - 1

--- a/Assets/Undead Survivor/Prefabs/Bullet 1.prefab
+++ b/Assets/Undead Survivor/Prefabs/Bullet 1.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 8964391082001240777}
   - component: {fileID: 765763602025172238}
   - component: {fileID: 8020119505041292121}
-  - component: {fileID: 3314559002311057259}
   m_Layer: 0
   m_Name: Bullet 1
   m_TagString: Bullet
@@ -162,26 +161,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d7c1becfe27c0d4ca0f2aa43bc81958, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 100
-  per: 0
---- !u!114 &3314559002311057259
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1272332711815712340}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895995249c05a36499e86d818ae1cb29, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bulletPrefabID: 0
-  coolTime: 0
   lifeTime: 0
-  damage: 0
+  damage: 100
   speed: 0
+  count: 0
+  attackCoolTime: 0
   scaleFactor: 0
   flightTime: 0
   rotateSpeed: 0
-  attackCoolTime: 0
+  playerTransform: {fileID: 0}
+  boltSpeed: 15
+  per: 0

--- a/Assets/Undead Survivor/Prefabs/Microprocessor.prefab
+++ b/Assets/Undead Survivor/Prefabs/Microprocessor.prefab
@@ -129,7 +129,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0d7c1becfe27c0d4ca0f2aa43bc81958, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  lifeTime: 0
   damage: 100
+  speed: 0
+  count: 0
+  attackCoolTime: 0
+  scaleFactor: 0
+  flightTime: 0
+  rotateSpeed: 0
+  playerTransform: {fileID: 0}
+  boltSpeed: 0
   per: -100
 --- !u!61 &1480564136679979604
 BoxCollider2D:
@@ -207,8 +216,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
-  - {fileID: 9043185136380304022}
   - {fileID: 5697661357337790576}
+  - {fileID: 9043185136380304022}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1315450137505496362


### PR DESCRIPTION
- 마프 총알을 Ai역시 가질 수 있게 만듦 + Enemy도 데미지 읽기 가능
- IoT가 날리는 총알은 기존 2번 Bullet이었는데 프리팹 변화없이 Bullet클래스를 BulletBase를 상속하도록 바꿈
- 스킬 타이머마다 가장 가까운 적이 존재하는지 판별하는 로직을 AI버전도 추가. 이제는 플레이어와 AI 모두 개별적이고 완전한 타이머를 가짐